### PR TITLE
[SW] Fix red channel overflow issues in the additive text drawing routine

### DIFF
--- a/engine/draw.c
+++ b/engine/draw.c
@@ -641,7 +641,7 @@ int Draw_MessageCharacterAdd( int x, int y, int num, int rr, int gg, int bb )
 			for (col = 0; col < charwidth; col++)
 			{
 				unsigned short newcolor, oldcolor;
-				unsigned short r, g, b;
+				int r, g, b;
 
 				if (source[col] != TRANSPARENT_COLOR)
 				{
@@ -675,7 +675,7 @@ int Draw_MessageCharacterAdd( int x, int y, int num, int rr, int gg, int bb )
 			for (col = 0; col < charwidth; col++)
 			{
 				unsigned short newcolor, oldcolor;
-				unsigned short r, g, b;
+				int r, g, b;
 
 				if (source[col] != TRANSPARENT_COLOR)
 				{


### PR DESCRIPTION
The additive text blending code may have red channel overflow issues in the 16bit path, resulting in a cyan-ish color when the text is overlaid on bright pixels (as indicated by the screenshot below), which is not observed in the vanilla build:
<img width="633" height="360" alt="13541fa1-8476-440e-aa86-2ed697445679" src="https://github.com/user-attachments/assets/c3881ba0-63bc-4e57-bec0-7ab095ae9897" />

This PR changes intermediate results to 32-bit according to the vanilla build, and fixes the issue:
<img width="641" height="327" alt="4814ea18-562b-41ef-bafb-1aa9f1bd725a" src="https://github.com/user-attachments/assets/b0296a54-d266-4b30-83f6-36d643127407" />
