### PR TITLE
Fix channel order issues in R_DrawDecals and R_DrawScaledDecal

### DIFF
--- a/engine/R_SURF.C
+++ b/engine/R_SURF.C
@@ -2154,9 +2154,7 @@ void R_DrawDecals( decal_t* list, byte* decalbuffer, int s, int t )
 					if (pix != TRANSPARENT_COLOR)
 					{
 						pColor = &ppalette[pix * 3];
-						pdest[0] = pColor[2];
-						pdest[1] = pColor[1];
-						pdest[2] = pColor[0];
+						*(int *)pdest = *(int *)pColor;
 						pdest[3] = 0;
 					}
 					pdest += 4;
@@ -2269,9 +2267,7 @@ void R_DrawScaledDecal( decal_t* list, byte* decalbuffer, int s, int t )
 				if (pix != TRANSPARENT_COLOR)
 				{
 					pColor = &ppalette[pix * 3];
-					pdest[0] = pColor[2];
-					pdest[1] = pColor[1];
-					pdest[2] = pColor[0];
+					*(int *)pdest = *(int *)pColor;
 					pdest[3] = 0;
 				}
 				pdest += 4;


### PR DESCRIPTION
Original HLNT `sw.dll` does not swap channels in these two functions. Not very easy to reproduce in game but there's evidence from the original binary:

`R_DrawDecals`:
<img width="921" height="568" alt="image" src="https://github.com/user-attachments/assets/82e9773a-9416-43a7-b4e0-338f00f43ec9" />

Same story for `R_DrawScaledDecal`:
<img width="886" height="786" alt="image" src="https://github.com/user-attachments/assets/2f76462a-ab31-4844-973f-19ac5cec27ae" />

